### PR TITLE
Fixed reaction issues with ~poll and added the ability to have more than 2 options

### DIFF
--- a/cogs/misc/misc_cog.py
+++ b/cogs/misc/misc_cog.py
@@ -129,14 +129,14 @@ class MiscCog(commands.Cog, name="Misc"):
         await ctx.reply(embed=meme)
 
     @commands.command()
-    async def poll(self, ctx: commands.Context, *poll: str, options: Optional[list[str]]=None):
+    async def poll(self, ctx: commands.Context, poll: str, *options: str):
         """
         🎲 Creates a simple yes or no poll.
 
         ❓ This command is also available as a slash command.
 
         You can create a simple yes or no poll by simply using `~poll`. You can,
-        however, add up to five options after the question.
+        however, add up to six options after the question.
 
         Usage:
         ```
@@ -151,24 +151,35 @@ class MiscCog(commands.Cog, name="Misc"):
             return await ctx.send(f':x: {ctx.author.mention}: You need to specify a question.')
 
         embed = discord.Embed(
-            title=f"Poll by **{ctx.author.name}**:",
-            description=" ".join(poll)
+            title=f"📢 Poll by **{ctx.author.name}**:",
+            description=f"```❓ {poll}```\n"
         )
 
         # If the user doesn't specify any options, just make a yes/no poll.
         if not options:
+            embed.set_footer(text='Vote ✔️ Yes or ❌ No.')
             message = await ctx.send(embed=embed)
 
             await message.add_reaction("✔️")
             return await message.add_reaction("❌")
 
-        reactions = [":one:", ":two", ":three:", ":four:", ":five:"]
+        key = {
+            "A": "🔴",
+            "B": "🟠",
+            "C": "🟡",
+            "D": "🟢",
+            "E": "🔵",
+            "F": "🟣"
+        }
 
-        for option, reaction in zip(options, reactions):
-            await message.add_reaction(reaction)
-            embed.add_field(name=f'Option {reaction}', value=option)
+        # Add fields
+        for (letter, emoji), option in zip(key.items(), options):
+            embed.add_field(name=f'{emoji} Option {letter}:', value=option, inline=False)
 
-        return await ctx.send(embed=embed)
+        # Send message and add reactions
+        message = await ctx.send(embed=embed)
+        for (letter, emoji), option in zip(key.items(), options):
+            await message.add_reaction(emoji)
 
 
 async def setup(client: commands.Bot):

--- a/cogs/misc/misc_cog.py
+++ b/cogs/misc/misc_cog.py
@@ -163,6 +163,12 @@ class MiscCog(commands.Cog, name="Misc"):
             await message.add_reaction("✔️")
             return await message.add_reaction("❌")
 
+        if len(options) < 2:
+            return await ctx.reply(f"❌ You need to add more than one option.")
+
+        if len(options) > 6:
+            return await ctx.reply(f"❌ You can't add more than 6 options.")
+
         key = {
             "A": "🔴",
             "B": "🟠",

--- a/cogs/misc/misc_cog.py
+++ b/cogs/misc/misc_cog.py
@@ -5,8 +5,9 @@ Contains miscellaneous commands to be used for fun.
 import datetime
 import random
 import humanize
-
 import discord
+
+from typing import Optional
 from discord.ext import commands
 from utils.models import TwitchBroadcast
 
@@ -128,19 +129,22 @@ class MiscCog(commands.Cog, name="Misc"):
         await ctx.reply(embed=meme)
 
     @commands.command()
-    async def poll(self, ctx: commands.Context, *poll: str):
+    async def poll(self, ctx: commands.Context, *poll: str, options: Optional[list[str]]=None):
         """
         🎲 Creates a simple yes or no poll.
 
         ❓ This command is also available as a slash command.
 
+        You can create a simple yes or no poll by simply using `~poll`. You can,
+        however, add up to five options after the question.
+
         Usage:
         ```
-        ~poll <question>
+        ~poll <question> [...options]
         ```
         Or:
         ```
-        /poll
+        /poll <question>
         ```
         """
         if not poll:
@@ -151,10 +155,20 @@ class MiscCog(commands.Cog, name="Misc"):
             description=" ".join(poll)
         )
 
-        message = await ctx.send(embed=embed)
+        # If the user doesn't specify any options, just make a yes/no poll.
+        if not options:
+            message = await ctx.send(embed=embed)
 
-        await message.add_reaction("✔️")
-        await message.add_reaction("❌")
+            await message.add_reaction("✔️")
+            return await message.add_reaction("❌")
+
+        reactions = [":one:", ":two", ":three:", ":four:", ":five:"]
+
+        for option, reaction in zip(options, reactions):
+            await message.add_reaction(reaction)
+            embed.add_field(name=f'Option {reaction}', value=option)
+
+        return await ctx.send(embed=embed)
 
 
 async def setup(client: commands.Bot):

--- a/handlers/event_handler.py
+++ b/handlers/event_handler.py
@@ -97,14 +97,13 @@ class EventHandler(commands.Cog):
         """
         Prevents users from voting more than once on a poll.
         """
-        user = reaction.message.author
         cached = discord.utils.get(self.client.cached_messages, id=reaction.message.id) # why
 
         if user.id == self.client.user.id:
             return
 
         for react in cached.reactions:
-            users = await react.users().flatten()
+            users = [user async for user in react.users()]
 
             if any({user not in users, user.bot, str(react) == str(reaction.emoji)}):
                 continue

--- a/handlers/event_handler.py
+++ b/handlers/event_handler.py
@@ -97,7 +97,7 @@ class EventHandler(commands.Cog):
         """
         Prevents users from voting more than once on a poll.
         """
-        cached = discord.utils.get(self.client.cached_messages, id=reaction.message.id) # why
+        cached = discord.utils.get(self.client.cached_messages, id=reaction.message.id)
 
         if user.id == self.client.user.id:
             return
@@ -105,7 +105,11 @@ class EventHandler(commands.Cog):
         for react in cached.reactions:
             users = [user async for user in react.users()]
 
-            if any({user not in users, user.bot, str(react) == str(reaction.emoji)}):
+            if any({
+                user not in users,
+                user.bot,
+                str(react) == str(reaction.emoji)
+            }):
                 continue
 
             await cached.remove_reaction(react.emoji, user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ yarl==1.7.2
 youtube-dl==2021.12.17
 pillow==9.0.1
 humanize
+jishaku @ git+https://github.com/Gorialis/jishaku

--- a/utils/buttons.py
+++ b/utils/buttons.py
@@ -62,6 +62,7 @@ class ClearMessagesView(discord.ui.View):
         await interaction.response.send_message('👍🏻 Aborting command!')
         await self.disable_all_buttons(interaction)
 
+
 class BlacklistClearButton(discord.ui.View):
     def __init__(self, ctx: commands.Context, *, data: dict, timeout: Optional[float] = 180):
         super().__init__(timeout=timeout)
@@ -139,6 +140,7 @@ class BlacklistModal(discord.ui.Modal):
             self.drop.words.append(self.text.value)
             await interaction.message.edit(view=self.view)
             return await super().on_submit(interaction=interaction)
+
 
 class BlacklistDropdown(discord.ui.Select):
     def __init__(self, ctx: commands.Context):


### PR DESCRIPTION
- Users can only react to a poll **once**.
- Users can create **yes/no** polls with `~poll <question>` and **multiple-choice** polls with `~poll <question> [...options]`.